### PR TITLE
Poprawka do adresu repozytorium

### DIFF
--- a/Labs.md
+++ b/Labs.md
@@ -114,4 +114,4 @@ Legenda:
 1. [Mateusz Gawin, Jakub Jabłoński, Daria Kotowicz i Magdalena Jędzierowska](https://github.com/matgawin/ruby-projekt2)
 1. [Cwilik Dawid](https://github.com/jodanpotasu/RubyZajecia2)
 1. [Patryk Adler, Michał Byszof, Maksymilian Kicki i Tomasz Cabaj](https://github.com/tcabaj/Ruby_2)
-1. [Radosław Gołuński, Patryk Pobłocki, Artur Radomski](https://github.com/ppoblocki/RubyProjekt2)
+1. [Radosław Gołuński, Patryk Pobłocki, Artur Radomski](https://github.com/ppoblocki/tar-egzamin)


### PR DESCRIPTION
Poprawny adres repozytorium do projektu na egzamin z Ruby

https://github.com/ppoblocki/tar-egzamin

Radosław Gołuński, Patryk Pobłocki, Artur Radomski